### PR TITLE
Move `concurrency` to ouroboros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ on:
         description: defines if docker build should be executed or not
         default: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   build:
     # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,10 +2,6 @@ name: dependabot auto merge
 on:
   workflow_call
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   dependabot_auto_merge:
     if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,10 +13,6 @@ on:
         description: Whether or not to run spotless
         default: true
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   linters:
     name: Linters
@@ -27,7 +23,6 @@ jobs:
       (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
-
       - name: Git Checkout
         if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11

--- a/.github/workflows/ouroboros.yml
+++ b/.github/workflows/ouroboros.yml
@@ -6,6 +6,10 @@ on:
   pull_request_target:
     types: [ opened, synchronize, reopened, ready_for_review ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pipeline:
     uses: yonatankarp/github-actions/.github/workflows/ci.yml@v1
@@ -18,7 +22,7 @@ jobs:
     uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v1
 
   linters:
-    uses: yonatankarp/github-actions/.github/workflows/linters.yml@v1
+    uses: yonatankarp/github-actions/.github/workflows/linters.yml@fix-linters-pipeline
     with:
       check_docs: true
       check_style: true


### PR DESCRIPTION
# Purpose

This commit moves the `concurrency` to ensure that jobs are not overriding their siblings and canceling each other. Moreover, the concurrency group was updated to also include the job id

# Types of changes

- [x] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [x] Documentation is updated
- [ ] No new tests are needed
