### PR TITLE
Use composite action in JAR release workflow

### DIFF
--- a/.github/actions/build-jar-artifact/action.yml
+++ b/.github/actions/build-jar-artifact/action.yml
@@ -1,11 +1,11 @@
 name: 'Jar Build Steps'
 description: 'Checks out code, sets up Java, and runs Gradle build'
 inputs:
-  tag:
-    description: 'Release tag for setting image version'
-    required: true
   module-name:
     description: 'Module name for Gradle build'
+    required: true
+  tag:
+    description: 'Release tag for setting image version'
     required: true
 
 runs:

--- a/.github/workflows/release-jar.yml
+++ b/.github/workflows/release-jar.yml
@@ -23,33 +23,12 @@ jobs:
     name: Artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
 
-      - name: Set Artifact Version
-        env:
-          release_tag: ${{ inputs.tag }}
-        run: |
-          echo Artifact version: ${release_tag}
-          echo "version=${release_tag}" > gradle.properties
-
-      - name: Install Java
-        uses: actions/setup-java@v4
+      - name: Build JAR artifact
+        uses: yonatankarp/github-actions/.github/actions/build-jar-artifact@main
         with:
-          java-version: 17
-          distribution: 'temurin'
-          #Instead of manually configure caching of gradle, use an action which is provided. Details here: https://github.com/actions/setup-java
-          cache: gradle
-
-      - name: Gradle Build
-        id: build
-        env:
-          module_name: ${{ inputs.module-name }}
-        run: |
-          if [ ! -n "$MODULE_NAME" ]; then
-            ./gradlew build
-          else
-            ./gradlew :${{ inputs.module-name }}:build
-          fi
+          module-name: ${{ input.module-name }}
+          tag: ${{ inputs.tag }}
 
       - name: Publish Artifact
         id: publish


### PR DESCRIPTION


# Purpose

This commit replaces the implementation of the `release-jar` workflow with the implementation of the composite action that was previously introduced.

This action would be later shared with the docker image release stage as well since the logic is identical

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [x] Documentation is updated
- [x] No new tests are needed
