### PR TITLE
Fix dependabot auto-tagging

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,6 +1,17 @@
 name: dependabot auto merge
 on:
   workflow_call:
+    inputs:
+      auto-update-tag:
+        type: boolean
+        description: Indicates weather or not to run the ./bin/replace-tag.sh to update the tag of repository after successful merge
+        default: false
+        required: false
+      tagging-script-path:
+        type: string
+        description: the path to the script to execute in order to tag the repository
+        required: false
+        default: ./bin/replace-tag.sh
     secrets:
       GITHUB_PAT:
         required: true
@@ -40,6 +51,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_PAT }}"
 
       - name: Move tag to current commit
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
-        run: sh ./bin/replace-tag.sh ${{ env.TAG_VERSION }}
+        if: ${{ inputs.auto-update-tag }} == true &&
+            (${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+            steps.metadata.outputs.update-type == 'version-update:semver-patch' }})
+        run: sh ${{ inputs.tagging-script-path }} ${{ env.TAG_VERSION }}

--- a/.github/workflows/ouroboros.yml
+++ b/.github/workflows/ouroboros.yml
@@ -27,6 +27,8 @@ jobs:
     needs: pipeline
     if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
     uses: ./.github/workflows/dependabot-auto-merge.yml
+    with:
+      auto-update-tag: true
     secrets:
       GITHUB_PAT: ${{ secrets.CI_PAT }}
 


### PR DESCRIPTION


# Purpose

This commit changes dependabot auto-tagging to be false by default, as it's currently used only in this repository, and fails in all else.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [x] Documentation is updated
- [x] No new tests are needed
