### PR TITLE
Fix `auto-update-tag` description

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       auto-update-tag:
         type: boolean
-        description: Indicates weather or not to run the ${{ inputs.tagging-script-path}} to update the tag of repository after successful merge
+        description: Indicates weather or not to run the inputs.tagging-script-path to update the tag of repository after successful merge
         default: false
         required: false
       tagging-script-path:


### PR DESCRIPTION

# Purpose

This commit fixes the description of `auto-update-tag` which broke the build as GitHub actions detected it as an attempt to evaluate the inputs

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] No new tests are needed
