### PR TITLE
Update to JVM 21

### DIFF
--- a/.github/actions/build-jar-artifact/action.yml
+++ b/.github/actions/build-jar-artifact/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Install Java
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: 21
         distribution: 'temurin'
         #Instead of manually configure caching of gradle, use an action which is provided. Details here: https://github.com/actions/setup-java
         cache: gradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
           # Instead of manually configure caching of gradle, use an action which
           # is provided. Details here: https://github.com/actions/setup-java

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install Java
         uses: actions/setup-java@v4
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
 
       - name: Update Gradle Wrapper


### PR DESCRIPTION

# Purpose

This commit updates the JVM installed on GitHub runner to version 21 instead of the previously used version 17.

# Types of changes

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
