### PR TITLE
Replace pull_request_target with `dependabot`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,10 @@ on:
 
 jobs:
   build:
-    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
-    # Otherwise, process it normally.
-    if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        if: github.event_name != 'pull_request_target'
+        if: github.actor != 'dependabot[bot]'
         uses: actions/checkout@v4
         # Do not trigger a checkout when opening PRs from a fork (helps avoid "pwn request".
         # See https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target)
@@ -40,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Dependabot Checkout
-        if: github.event_name == 'pull_request_target'
+        if: github.actor == 'dependabot[bot]'
         uses: actions/checkout@v4
         with:
           # Dependabot can only checkout at the HEAD of the PR branch

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   dependabot_auto_merge:
-    if: ${{ github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]' }}
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       TAG_VERSION: "v1"

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,21 +16,16 @@ on:
 jobs:
   linters:
     name: Linters
-    # If the PR is coming from a fork (pull_request_target), ensure it's opened by "dependabot[bot]".
-    # Otherwise, clone it normally.
-    if: |
-      (github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]') ||
-      (github.event_name != 'pull_request_target' && github.actor != 'dependabot[bot]')
     runs-on: ubuntu-latest
     steps:
       - name: Git Checkout
-        if: ${{ github.event_name != 'pull_request_target' }}
+        if: github.actor != 'dependabot[bot]'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Checkout PR
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: github.actor == 'dependabot[bot]'
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/update-gradle-wrapper.yml
+++ b/.github/workflows/update-gradle-wrapper.yml
@@ -12,7 +12,6 @@ jobs:
 
     steps:
       - name: Checkout PR
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0


### PR DESCRIPTION


# Purpose

This commit replaces the `pull_request_target` rule with `dependabot` actor to ensure all dependabot actions are picked

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
