### PR TITLE
Update dependabot auto merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,66 +1,68 @@
 name: dependabot auto merge
+
 on:
   workflow_call:
     inputs:
       auto-update-tag:
         type: boolean
-        description: Indicates weather or not to run the inputs {{ tagging-script-path }} to update the tag of repository after successful merge
+        description: Run tagging script after successful merge
         default: false
         required: false
       tagging-script-path:
         type: string
-        description: the path to the script to execute in order to tag the repository
-        required: false
+        description: Path to a script that tags the repo
         default: ./bin/replace-tags.sh
+        required: false
     secrets:
       GITHUB_PAT:
-        required: true
-        description: PAT with access of merging PRs to the repository
+        required: false
+        description: Optional PAT if you need a human approval identity
 
 jobs:
   dependabot_auto_merge:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     env:
-      TAG_VERSION: "v1"
-    steps:
+      TAG_VERSION: v1
+      # Prefer PAT if provided; else use the workflow token
+      GH_TOKEN: ${{ secrets.GITHUB_PAT || github.token }}
+      PR_URL: ${{ github.event.pull_request.html_url }}
 
-      - name: Dependabot Checkout
-        if: ${{ inputs.auto-update-tag  == true && github.event_name == 'pull_request_target' }}
+    steps:
+      # Only needed if you actually run a script from the repo (tagging)
+      - name: Checkout (for tagging script)
+        if: inputs.auto-update-tag
         uses: actions/checkout@v4
         with:
-          # Dependabot can only checkout at the HEAD of the PR branch
+          # For Dependabot PRs in the same repo this is safe
           ref: ${{ github.event.pull_request.head.sha }}
-          submodules: 'recursive'
-          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: recursive
+          token: ${{ env.GH_TOKEN }}
 
-      # If the PR is created by Dependabot run additional steps
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: ${{ env.GH_TOKEN }}
 
-      - name: Approve a Dependabot PR
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
-        # Approving the PR and waiting for 5 sec to let GitHub UI to reflect the changes
-        run: gh pr review --approve "$PR_URL" && sleep 5
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: "${{ secrets.GITHUB_PAT }}"
+      - name: Approve a Dependabot PR (minor/patch)
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
 
-      - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+      - name: Enable auto-merge (minor/patch)
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
         run: gh pr merge --auto --rebase "$PR_URL"
-        id: auto-merge
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: "${{ secrets.GITHUB_PAT }}"
 
       - name: Move tag to current commit
-        if: ${{ inputs.auto-update-tag == 'true' && 
-              (steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
-               steps.metadata.outputs.update-type == 'version-update:semver-patch') }}
-        run: sh ${{ inputs.tagging-script-path }} ${{ env.TAG_VERSION }}
+        if: |
+          inputs.auto-update-tag &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: sh "${{ inputs.tagging-script-path }}" "${{ env.TAG_VERSION }}"


### PR DESCRIPTION

# Purpose

This commit updates the setup of dependabot auto merge to favour the context of `pull_request` rather than `pull_request_target` as part of a longer plan to deprecate the old usage of 2 different pipelines for dependabot and for regular pull requests causing multiple issues that are noticeable only when dependabot creating a pr

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] No new tests are needed
