### PR TITLE
Replace dummy modules with real Spring Boot and Ktor skeletons

### DIFF
--- a/.github/workflows/ouroboros.yml
+++ b/.github/workflows/ouroboros.yml
@@ -12,29 +12,32 @@ permissions:
   contents: write
 
 jobs:
-  pipeline_spring:
-    name: "[ test ] pipeline - spring skeleton"
+  pipeline:
+    name: "[ test ] pipeline"
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: spring-skeleton
+            app_name: spring-skeleton
+            dockerfile_path: skeletons/spring/Dockerfile
+            build_dockerfile: true
+          - variant: ktor-skeleton-uppercase
+            app_name: KTOR-SKELETON
+            dockerfile_path: skeletons/ktor/Dockerfile
+            build_dockerfile: true
+          - variant: spring-skeleton-no-docker
+            app_name: spring-skeleton
+            dockerfile_path: ""
+            build_dockerfile: false
     uses: ./.github/workflows/ci.yml
     with:
-      app_name: spring-skeleton
-      dockerfile_path: skeletons/spring/Dockerfile
-
-  pipeline_ktor_uppercase:
-    name: "[ test ] pipeline - ktor skeleton (uppercase image name sanitization)"
-    uses: ./.github/workflows/ci.yml
-    with:
-      app_name: KTOR-SKELETON
-      dockerfile_path: skeletons/ktor/Dockerfile
-
-  pipeline_no_docker:
-    name: "[ test ] pipeline - skip docker build"
-    uses: ./.github/workflows/ci.yml
-    with:
-      app_name: spring-skeleton
-      build_dockerfile: false
+      app_name: ${{ matrix.app_name }}
+      dockerfile_path: ${{ matrix.dockerfile_path }}
+      build_dockerfile: ${{ matrix.build_dockerfile }}
 
   dependabot_auto_merge:
-    needs: pipeline_spring
+    needs: pipeline
     if: ${{ github.actor == 'dependabot[bot]' }}
     uses: ./.github/workflows/dependabot-auto-merge.yml
     permissions:
@@ -62,3 +65,17 @@ jobs:
       - uses: actions/checkout@v6
 
       - uses: devops-actions/actionlint@v0.1.12
+
+  all-green:
+    name: All checks passed
+    needs:
+      - pipeline
+      - linters
+      - update-gradle-wrapper
+      - actions-linter
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs) }}

--- a/.github/workflows/ouroboros.yml
+++ b/.github/workflows/ouroboros.yml
@@ -67,7 +67,6 @@ jobs:
       - uses: devops-actions/actionlint@v0.1.12
 
   all-green:
-    name: All checks passed
     needs:
       - pipeline
       - linters

--- a/.github/workflows/ouroboros.yml
+++ b/.github/workflows/ouroboros.yml
@@ -12,40 +12,29 @@ permissions:
   contents: write
 
 jobs:
-  pipeline:
+  pipeline_spring:
+    name: "[ test ] pipeline - spring skeleton"
     uses: ./.github/workflows/ci.yml
     with:
-      app_name: dummy-app
+      app_name: spring-skeleton
+      dockerfile_path: skeletons/spring/Dockerfile
 
-  pipeline_dockerfile_test:
-    name: "[ test ] pipeline - dockerfile on project root directory"
+  pipeline_ktor_uppercase:
+    name: "[ test ] pipeline - ktor skeleton (uppercase image name sanitization)"
     uses: ./.github/workflows/ci.yml
     with:
-      app_name: dummy-app
-      dockerfile_path: "./Dockerfile"
+      app_name: KTOR-SKELETON
+      dockerfile_path: skeletons/ktor/Dockerfile
 
-  pipeline_docker_image_name_uppoercase:
-    name: "[ test ] pipeline - docker image name contains mixture of upper and lower letters"
+  pipeline_no_docker:
+    name: "[ test ] pipeline - skip docker build"
     uses: ./.github/workflows/ci.yml
     with:
-      app_name: Yet-Another-Dummy-App
-
-  pipeline_gradle_build_root:
-    name: "[ test ] pipeline - gradle build on project root directory"
-    uses: ./.github/workflows/ci.yml
-    with:
-      app_name: dummy-app
-      context: "."
-
-  pipeline_gradle_build_submodule:
-    name: "[ test ] pipeline - gradle build on project submodule directory"
-    uses: ./.github/workflows/ci.yml
-    with:
-      app_name: dummy-app
-      context: dummy-app
+      app_name: spring-skeleton
+      build_dockerfile: false
 
   dependabot_auto_merge:
-    needs: pipeline
+    needs: pipeline_spring
     if: ${{ github.actor == 'dependabot[bot]' }}
     uses: ./.github/workflows/dependabot-auto-merge.yml
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM eclipse-temurin:17-jre-alpine

--- a/Yet-Another-Dummy-App/Dockerfile
+++ b/Yet-Another-Dummy-App/Dockerfile
@@ -1,1 +1,0 @@
-FROM eclipse-temurin:17-jre-alpine

--- a/Yet-Another-Dummy-App/build.gradle.kts
+++ b/Yet-Another-Dummy-App/build.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-    kotlin("jvm") version "2.3.21"
-}
-
-repositories {
-    mavenCentral()
-}

--- a/dummy-app/Dockerfile
+++ b/dummy-app/Dockerfile
@@ -1,1 +1,0 @@
-FROM eclipse-temurin:17-jre-alpine

--- a/dummy-app/build.gradle.kts
+++ b/dummy-app/build.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-    kotlin("jvm") version "2.3.21"
-}
-
-repositories {
-    mavenCentral()
-}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 rootProject.name = "github-actions"
 
-include(
-    "dummy-app",
-    "Yet-Another-Dummy-App",
-)
+include("skeletons:spring", "skeletons:ktor")
+
+project(":skeletons:spring").projectDir = file("skeletons/spring")
+project(":skeletons:ktor").projectDir = file("skeletons/ktor")

--- a/skeletons/ktor/Dockerfile
+++ b/skeletons/ktor/Dockerfile
@@ -1,0 +1,3 @@
+FROM eclipse-temurin:25-jre-alpine
+COPY skeletons/ktor/build/libs/ktor-skeleton.jar /app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/skeletons/ktor/build.gradle.kts
+++ b/skeletons/ktor/build.gradle.kts
@@ -1,0 +1,34 @@
+plugins {
+    kotlin("jvm") version "2.3.21"
+    id("io.ktor.plugin") version "3.5.0"
+}
+
+kotlin {
+    jvmToolchain(25)
+}
+
+repositories {
+    mavenCentral()
+}
+
+application {
+    mainClass.set("com.yonatankarp.skeleton.ktor.ApplicationKt")
+}
+
+ktor {
+    fatJar {
+        archiveFileName.set("ktor-skeleton.jar")
+    }
+}
+
+dependencies {
+    implementation("io.ktor:ktor-server-core")
+    implementation("io.ktor:ktor-server-netty")
+    implementation("ch.qos.logback:logback-classic:1.5.32")
+    testImplementation("io.ktor:ktor-server-test-host")
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/skeletons/ktor/src/main/kotlin/com/yonatankarp/skeleton/ktor/Application.kt
+++ b/skeletons/ktor/src/main/kotlin/com/yonatankarp/skeleton/ktor/Application.kt
@@ -1,0 +1,20 @@
+package com.yonatankarp.skeleton.ktor
+
+import io.ktor.server.application.Application
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.get
+import io.ktor.server.routing.routing
+
+fun main() {
+    embeddedServer(Netty, port = 8080, host = "0.0.0.0", module = Application::module).start(wait = true)
+}
+
+fun Application.module() {
+    routing {
+        get("/") {
+            call.respondText("Hello from Ktor")
+        }
+    }
+}

--- a/skeletons/ktor/src/test/kotlin/com/yonatankarp/skeleton/ktor/ApplicationTest.kt
+++ b/skeletons/ktor/src/test/kotlin/com/yonatankarp/skeleton/ktor/ApplicationTest.kt
@@ -1,0 +1,18 @@
+package com.yonatankarp.skeleton.ktor
+
+import io.ktor.client.request.get
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ApplicationTest {
+    @Test
+    fun testRoot() = testApplication {
+        application { module() }
+        val response = client.get("/")
+        assertEquals(HttpStatusCode.OK, response.status)
+        assertEquals("Hello from Ktor", response.bodyAsText())
+    }
+}

--- a/skeletons/spring/Dockerfile
+++ b/skeletons/spring/Dockerfile
@@ -1,0 +1,3 @@
+FROM eclipse-temurin:25-jre-alpine
+COPY skeletons/spring/build/libs/*.jar /app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/skeletons/spring/build.gradle.kts
+++ b/skeletons/spring/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.spring") version "2.3.21"
+    id("org.springframework.boot") version "4.0.6"
+    id("io.spring.dependency-management") version "1.1.7"
+}
+
+kotlin {
+    jvmToolchain(25)
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.jar {
+    enabled = false
+}

--- a/skeletons/spring/src/main/kotlin/com/yonatankarp/skeleton/spring/Application.kt
+++ b/skeletons/spring/src/main/kotlin/com/yonatankarp/skeleton/spring/Application.kt
@@ -1,0 +1,19 @@
+package com.yonatankarp.skeleton.spring
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@SpringBootApplication
+class Application
+
+@RestController
+class HelloController {
+    @GetMapping("/")
+    fun hello() = "Hello from Spring"
+}
+
+fun main(args: Array<String>) {
+    runApplication<Application>(*args)
+}

--- a/skeletons/spring/src/test/kotlin/com/yonatankarp/skeleton/spring/ApplicationTest.kt
+++ b/skeletons/spring/src/test/kotlin/com/yonatankarp/skeleton/spring/ApplicationTest.kt
@@ -1,0 +1,11 @@
+package com.yonatankarp.skeleton.spring
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class ApplicationTest {
+    @Test
+    fun contextLoads() {
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces empty `dummy-app/` and `Yet-Another-Dummy-App/` with minimal-but-real Spring Boot + Ktor skeletons under `skeletons/`.
- `ouroboros.yml` now exercises 3 meaningful test variants (was 5; two prior tests depended on broken behavior — see follow-ups).
- Local `./gradlew clean build` green in ~21s. Both skeletons produce runnable JARs (`spring.jar` bootJar, `ktor-skeleton.jar` fatJar).

## Why
The previous dummy modules had no `src/`, so `ci.yml`'s paths-filter (`${context}/src/**`) never matched — every ouroboros run was a silent no-op. This is phase 1 of preparing for the v2 `ci.yml` redesign: the self-tests have to be real before we can trust ouroboros to catch regressions in the upcoming composite-action extraction.

## Skeleton choices
- **Spring**: Spring Boot 4.0.6, dep-management 1.1.7, Kotlin 2.3.21, JDK 25 toolchain. `tasks.jar { enabled = false }` so only the bootJar lands in `build/libs/`.
- **Ktor**: Ktor 3.5.0, Kotlin 2.3.21, Logback 1.5.32, JDK 25 toolchain. Fat jar pinned to `ktor-skeleton.jar` so the Dockerfile `COPY` is unambiguous.
- Versions match the real reference templates (`spring-starter`, `ktor-template`) so dependabot bumps stay in sync.

## Test plan
- [x] `./gradlew clean build` passes locally
- [x] Both skeletons produce runnable JARs
- [ ] `ouroboros` workflow runs green on this PR
- [ ] Docker builds succeed for both skeletons in CI (`pipeline_spring`, `pipeline_ktor_uppercase`)
- [ ] Image-name sanitization still works for the uppercase test variant

## Known follow-ups (deferred to v2)
- `ci.yml`'s paths-filter uses `${context}/src/**`, which won't match `skeletons/spring/src/**`. Fix lands with v2 input redesign.
- `ci.yml` installs JDK 21 but skeletons pin JDK 25 → Gradle auto-provisions JDK 25 each CI run. v2 adds a `jvm-version` input.
- Submodule-build code path in `ci.yml` is no longer exercised (current `context` input doesn't handle nested paths like `skeletons/spring`). v2 restores coverage with a `gradle-module` input.
- Root `build.gradle.kts` still has the dead `maven-publish` block. Deletes with v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)