### PR TITLE
Fix self-checkout: parse workflow_ref instead of workflow_sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,17 @@ jobs:
         with:
           submodules: ${{ inputs.submodules }}
 
+      - name: Resolve Composite Actions Ref
+        id: composite-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: echo "ref=${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout Composite Actions
         uses: actions/checkout@v6
         with:
           repository: yonatankarp/github-actions
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.composite-ref.outputs.ref }}
           path: composite-actions
           clean: false
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -47,11 +47,17 @@ jobs:
           submodules: 'recursive'
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve Composite Actions Ref
+        id: composite-ref
+        env:
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+        run: echo "ref=${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
+
       - name: Checkout Composite Actions
         uses: actions/checkout@v6
         with:
           repository: yonatankarp/github-actions
-          ref: ${{ github.workflow_sha }}
+          ref: ${{ steps.composite-ref.outputs.ref }}
           path: composite-actions
           clean: false
 


### PR DESCRIPTION
## Summary
Cross-repo consumers calling ci.yml@v2 fail at the "Checkout Composite Actions" step with:
\`\`\`
fatal: remote error: upload-pack: not our ref <consumer-sha>
\`\`\`

Root cause: \`github.workflow_sha\` returns the **calling repo's** commit SHA, not the called workflow's SHA (despite the docs implying otherwise). For a cross-repo consumer, that SHA doesn't exist in yonatankarp/github-actions, so the checkout fails.

## Fix
Parse \`github.workflow_ref\` instead. It's always in the form \`owner/repo/path@ref\`, e.g. \`yonatankarp/github-actions/.github/workflows/ci.yml@refs/tags/v2\`. A one-line shell step extracts the ref portion, then \`actions/checkout\` uses it.

This works in both directions:
- Consumer call \`@v2\` → ref = \`refs/tags/v2\` → composite-actions/ pinned to v2 ✓
- Ouroboros local call → ref = \`refs/pull/N/merge\` → composite-actions/ pinned to PR's merge ref ✓

## Test plan
- [ ] Ouroboros runs green (validates the local-call path)
- [ ] After merge + retag of v2, re-run kotlin-spring-boot-template#449 — should go green (validates the cross-repo path)

Discovered while migrating kotlin-spring-boot-template to v2 (PR #449 in that repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)