### PR TITLE
Drop self-checkout: reference composites by full @v2 path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,40 +52,26 @@ jobs:
         with:
           submodules: ${{ inputs.submodules }}
 
-      - name: Resolve Composite Actions Ref
-        id: composite-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: echo "ref=${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout Composite Actions
-        uses: actions/checkout@v6
-        with:
-          repository: yonatankarp/github-actions
-          ref: ${{ steps.composite-ref.outputs.ref }}
-          path: composite-actions
-          clean: false
-
-      - uses: ./composite-actions/.github/actions/prepare-jvm-build
+      - uses: yonatankarp/github-actions/.github/actions/prepare-jvm-build@v2
         with:
           jvm-version: ${{ inputs.jvm-version }}
           jvm-distribution: ${{ inputs.jvm-distribution }}
 
       - id: changes
-        uses: ./composite-actions/.github/actions/detect-source-changes
+        uses: yonatankarp/github-actions/.github/actions/detect-source-changes@v2
         with:
           dockerfile-path: ${{ inputs.dockerfile-path }}
 
       - if: steps.changes.outputs.source_code == 'true'
-        uses: ./composite-actions/.github/actions/gradle-build
+        uses: yonatankarp/github-actions/.github/actions/gradle-build@v2
         with:
           gradle-module: ${{ inputs.gradle-module }}
 
       - if: always() && inputs.publish-test-reports
-        uses: ./composite-actions/.github/actions/publish-test-reports
+        uses: yonatankarp/github-actions/.github/actions/publish-test-reports@v2
 
       - if: inputs.dockerfile-path != '' && steps.changes.outputs.source_code == 'true'
-        uses: ./composite-actions/.github/actions/build-docker-image
+        uses: yonatankarp/github-actions/.github/actions/build-docker-image@v2
         with:
           image-name: ${{ inputs.image-name }}
           dockerfile-path: ${{ inputs.dockerfile-path }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -47,21 +47,7 @@ jobs:
           submodules: 'recursive'
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve Composite Actions Ref
-        id: composite-ref
-        env:
-          WORKFLOW_REF: ${{ github.workflow_ref }}
-        run: echo "ref=${WORKFLOW_REF##*@}" >> "$GITHUB_OUTPUT"
-
-      - name: Checkout Composite Actions
-        uses: actions/checkout@v6
-        with:
-          repository: yonatankarp/github-actions
-          ref: ${{ steps.composite-ref.outputs.ref }}
-          path: composite-actions
-          clean: false
-
-      - uses: ./composite-actions/.github/actions/prepare-jvm-build
+      - uses: yonatankarp/github-actions/.github/actions/prepare-jvm-build@v2
         with:
           jvm-version: ${{ inputs.jvm-version }}
           jvm-distribution: ${{ inputs.jvm-distribution }}
@@ -87,7 +73,8 @@ jobs:
           if [[ -n "$OVERRIDE" ]]; then
             echo "path=$OVERRIDE" >> "$GITHUB_OUTPUT"
           else
-            echo "path=./composite-actions/config/markdown-lint/rules.json" >> "$GITHUB_OUTPUT"
+            curl -fsSL https://raw.githubusercontent.com/yonatankarp/github-actions/v2/config/markdown-lint/rules.json -o /tmp/markdown-lint-rules.json
+            echo "path=/tmp/markdown-lint-rules.json" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Lint Documents


### PR DESCRIPTION
## Summary
Both \`github.workflow_sha\` and \`github.workflow_ref\` return the **calling** workflow's context inside a reusable workflow, not the called workflow's. The self-checkout pattern fails for any cross-repo caller — exactly what kotlin-spring-boot-template#449 just hit:
\`\`\`
fatal: couldn't find remote ref refs/pull/449/merge   ← caller's ref, not ours
\`\`\`

## Fix
Drop the self-checkout step entirely. Reference composite actions by full registry path with \`@v2\` pinned: \`uses: yonatankarp/github-actions/.github/actions/prepare-jvm-build@v2\`. GitHub auto-fetches them at workflow startup — no extra checkout.

For the bundled markdown-lint config, fetch via \`curl\` from \`raw.githubusercontent.com/yonatankarp/github-actions/v2/config/...\` when no override is provided. One inline shell line, no second checkout.

## Trade-off
PRs to this repo that change composite behavior won't have their NEW composites tested by ouroboros — ouroboros tests against whatever \`@v2\` points at, which is the previous main commit. For this repo's traffic (mostly dependabot bumps + occasional structural changes), the drift is acceptable. Mitigation: review the composite diff carefully before merging.

## Test plan
- [ ] Ouroboros runs green (validates the new path resolution end-to-end)
- [ ] After merge + retag of v2, re-run kotlin-spring-boot-template#449 — should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)