### PR TITLE
Include workflow/action paths in source-changes filter

### DIFF
--- a/.github/actions/detect-source-changes/action.yml
+++ b/.github/actions/detect-source-changes/action.yml
@@ -20,6 +20,8 @@ runs:
       with:
         filters: |
           source_code:
+            - '.github/workflows/**'
+            - '.github/actions/**'
             - '**/src/**'
             - '**/build.gradle.kts'
             - 'gradle/libs.versions.toml'


### PR DESCRIPTION
Restores v1 behavior where workflow-only changes (e.g. v2 migration PRs in consumer repos) trigger a real build. v2's filter dropped \`.github/workflows/**\` inadvertently, causing consumer migration PRs to report green while gradle-build and docker-build silently skip. Also adds \`.github/actions/**\` so composite changes in this repo get the same gate.

Caught on domain-gateway-demo#246 — 20s "green" run with build steps marked skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)