### PR TITLE
Per-module test result check + artifact name

### DIFF
--- a/.github/actions/publish-test-reports/action.yml
+++ b/.github/actions/publish-test-reports/action.yml
@@ -10,6 +10,10 @@ inputs:
     description: 'Name of the uploaded artifact bundle.'
     required: false
     default: 'test-reports'
+  check-name:
+    description: 'Name of the GitHub Check that displays the test results. Pass a unique value per matrix variant to avoid clobbering.'
+    required: false
+    default: 'Test Results'
 
 runs:
   using: composite
@@ -19,6 +23,7 @@ runs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       with:
         junit_files: ${{ inputs.junit-pattern }}
+        check_name: ${{ inputs.check-name }}
 
     - name: Upload test and coverage reports
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
 
       - if: always() && inputs.publish-test-reports
         uses: yonatankarp/github-actions/.github/actions/publish-test-reports@v2
+        with:
+          check-name: Test Results (${{ inputs.image-name }})
+          artifact-name: test-reports-${{ inputs.image-name }}
 
       - if: inputs.dockerfile-path != '' && steps.changes.outputs.source_code == 'true'
         uses: yonatankarp/github-actions/.github/actions/build-docker-image@v2


### PR DESCRIPTION
## Summary
\`publish-test-reports\` gains a \`check-name\` input (default \`Test Results\` for backwards compat). \`ci.yml\` passes \`Test Results (\${{ image-name }})\` so matrix-driven consumers get **one check per variant** instead of overwriting each other under a single \`Test Results\` name. Artifact upload gets the same image-name suffix so the matrix entries don't collide on \`actions/upload-artifact\`'s unique-name requirement either.

## Why
Caught on domain-gateway-demo#246 — three matrix entries (domain-gateway, hello-service, goodbye-service) each tried to publish results to the same \`Test Results\` check. Only the last entry's counts (4 tests / 2 suites) were visible; the other two were clobbered.

## After this lands
- Consumers with a matrix get distinct checks: \`Test Results (domain-gateway)\`, \`Test Results (hello-service)\`, etc.
- Consumers without a matrix see \`Test Results (<image-name>)\` — slightly redundant but consistent.
- No consumer needs to change inputs; the ci.yml change is internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline test reporting configuration to allow customizable check names for published test results, enabling better organization when building multiple images.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yonatankarp/github-actions/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->