### PR TITLE
Restore name: Linters on the linters job

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -30,6 +30,7 @@ on:
 
 jobs:
   linters:
+    name: Linters
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
v1's linters.yml had \`name: Linters\` on the linters job, making the consumer-visible check name \`linters / Linters\`. v2 dropped it; the check became \`linters / linters\`, which silently breaks every consumer that requires the v1 spelling in branch protection / rulesets.

Restoring the friendly name keeps the public check identifier stable across the migration. Consumers don't need to touch their protection settings.

## Discovered on
- domain-gateway-demo#246 (had to rename the protection context)
- xkcd-data-hub-lite#267 (ruleset \`Branch Protection - Default Branch\` blocks until match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)