### PR TITLE
Expose GITHUB_TOKEN as env on ci.yml's build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       contents: read
       pull-requests: write
       checks: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6


### PR DESCRIPTION
v1's ci.yml set \`GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}\` as env on the gradle step so gradle could authenticate against GitHub Packages. v2 dropped it when the gradle-build composite was extracted.

Caught by cat-fact-service#116 — gradle build fails with \`401 Unauthorized\` resolving \`com.yonatankarp:cat-fact-client\` from \`maven.pkg.github.com\`.

Setting it at the job level so every step (including gradle-build) sees it. Consumers that need GitHub Packages access still need to grant \`packages: read\` permission on the calling job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)