### PR TITLE
Add release-docker-ghcr reusable workflow

### DIFF
--- a/.github/actions/publish-docker-image/README.md
+++ b/.github/actions/publish-docker-image/README.md
@@ -1,0 +1,72 @@
+# `publish-docker-image`
+
+Composite action that builds a multi-arch Docker image with `buildx` and pushes it to the specified container registry. Registry-agnostic: the caller supplies the registry hostname and credentials. Used internally by the `release-docker-ghcr.yml` reusable workflow; will also back the future `release-docker-dockerhub.yml`.
+
+Steps it performs:
+
+1. `actions/checkout@v6`
+2. `docker/setup-qemu-action@v3` (for cross-arch emulation)
+3. `docker/setup-buildx-action@v3`
+4. `docker/login-action@v3` against `inputs.registry`
+5. `docker/metadata-action@v5` to compute tags (`<tag>`, optionally `latest`) and OCI labels
+6. `docker/build-push-action@v6` with provenance attestation
+
+## Inputs
+
+| Name            | Required | Default                     | Description                                                                                  |
+|-----------------|----------|-----------------------------|----------------------------------------------------------------------------------------------|
+| `registry`      | yes      | —                           | Container registry hostname (e.g. `ghcr.io`, `docker.io`).                                   |
+| `image-name`    | yes      | —                           | Image name under the registry (e.g. `yonatankarp/cat-fact-service`).                         |
+| `tag`           | yes      | —                           | Primary image tag (e.g. `1.2.3`).                                                            |
+| `username`      | yes      | —                           | Registry username.                                                                           |
+| `password`      | yes      | —                           | Registry password or access token. See "Secrets" note below.                                 |
+| `dockerfile`    | no       | `./Dockerfile`              | Path to the Dockerfile.                                                                      |
+| `build-context` | no       | `.`                         | Docker build context directory.                                                              |
+| `platforms`     | no       | `linux/amd64,linux/arm64`   | Comma-separated buildx target platforms.                                                     |
+| `latest`        | no       | `true`                      | Also tag the image as `:latest`. Pass `"true"` or `"false"`.                                 |
+| `provenance`    | no       | `mode=min`                  | Provenance attestation setting (`mode=min`, `mode=max`, `false`).                            |
+
+## Secrets
+
+Composite actions cannot accept GitHub Actions `secrets` directly — only `inputs`. The caller must pass the secret **value** to `password`, e.g.:
+
+```yaml
+with:
+  password: ${{ secrets.GITHUB_TOKEN }}        # GHCR
+  # or
+  password: ${{ secrets.DOCKERHUB_TOKEN }}     # Docker Hub
+```
+
+## Required caller permissions
+
+For GHCR pushes, the calling job needs:
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+```
+
+For Docker Hub, only `contents: read` is needed (auth is via Docker Hub credentials, not the GitHub token).
+
+## Usage
+
+Direct call from a job (rare — most callers should use the higher-level reusable workflows instead):
+
+```yaml
+- name: Publish to GHCR
+  uses: yonatankarp/github-actions/.github/actions/publish-docker-image@v2
+  with:
+    registry: ghcr.io
+    image-name: ${{ github.repository }}
+    tag: ${{ github.event.release.tag_name }}
+    username: ${{ github.actor }}
+    password: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Notes
+
+- **Multi-arch build time:** `linux/arm64` is emulated via QEMU on `ubuntu-latest` runners, which is 3–5× slower than native amd64.
+- **Provenance:** `mode=min` attaches signed metadata linking the image to the workflow run. Set `provenance: false` to disable, or `mode=max` for fuller build-step details.

--- a/.github/actions/publish-docker-image/action.yml
+++ b/.github/actions/publish-docker-image/action.yml
@@ -1,0 +1,83 @@
+name: 'Publish Docker Image'
+description: |
+  Checks out code, builds a multi-arch Docker image with buildx, and pushes
+  it to the specified registry with metadata-driven tagging and provenance
+  attestation. Registry-agnostic — caller supplies registry hostname and
+  credentials.
+
+inputs:
+  registry:
+    description: 'Container registry hostname (e.g. `ghcr.io`, `docker.io`).'
+    required: true
+  image-name:
+    description: 'Image name under the registry (e.g. `yonatankarp/cat-fact-service`). Final image is `<registry>/<image-name>`.'
+    required: true
+  tag:
+    description: 'Primary image tag (e.g. `1.2.3`).'
+    required: true
+  username:
+    description: 'Registry username.'
+    required: true
+  password:
+    description: 'Registry password or access token. Composite actions cannot accept secrets directly — caller must pass the secret value as a string input.'
+    required: true
+  dockerfile:
+    description: 'Path to the Dockerfile.'
+    required: false
+    default: './Dockerfile'
+  build-context:
+    description: 'Docker build context directory.'
+    required: false
+    default: '.'
+  platforms:
+    description: 'Comma-separated buildx target platforms.'
+    required: false
+    default: 'linux/amd64,linux/arm64'
+  latest:
+    description: 'Also tag the image as `:latest`. Accepts `"true"` or `"false"`.'
+    required: false
+    default: 'true'
+  provenance:
+    description: 'Provenance attestation setting passed to `docker/build-push-action` (e.g. `mode=min`, `mode=max`, `false`).'
+    required: false
+    default: 'mode=min'
+
+runs:
+  using: 'composite'
+  steps:
+
+    - name: Checkout Code
+      uses: actions/checkout@v6
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Compute tags & labels
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ inputs.registry }}/${{ inputs.image-name }}
+        tags: |
+          type=raw,value=${{ inputs.tag }}
+          type=raw,value=latest,enable=${{ inputs.latest }}
+
+    - name: Build & push
+      uses: docker/build-push-action@v6
+      with:
+        context: ${{ inputs.build-context }}
+        file: ${{ inputs.dockerfile }}
+        platforms: ${{ inputs.platforms }}
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        provenance: ${{ inputs.provenance }}

--- a/.github/workflows/release-docker-ghcr.md
+++ b/.github/workflows/release-docker-ghcr.md
@@ -4,6 +4,8 @@ Reusable workflow that builds a multi-arch Docker image and pushes it to GitHub 
 
 Mirrors the shape of [`release-jar.yml`](./release-jar.yml) — the caller wires up its own trigger (typically on release/tag).
 
+Internally delegates to the [`publish-docker-image`](../actions/publish-docker-image) composite action, which is registry-agnostic and shared with the upcoming Docker Hub release workflow.
+
 ## Inputs
 
 | Name            | Required | Default                     | Description                                                                                  |

--- a/.github/workflows/release-docker-ghcr.md
+++ b/.github/workflows/release-docker-ghcr.md
@@ -1,0 +1,69 @@
+# `release-docker-ghcr.yml`
+
+Reusable workflow that builds a multi-arch Docker image and pushes it to GitHub Container Registry (GHCR), tagged with the supplied release tag (and optionally `:latest`).
+
+Mirrors the shape of [`release-jar.yml`](./release-jar.yml) — the caller wires up its own trigger (typically on release/tag).
+
+## Inputs
+
+| Name            | Required | Default                     | Description                                                                                  |
+|-----------------|----------|-----------------------------|----------------------------------------------------------------------------------------------|
+| `tag`           | yes      | —                           | Release tag (e.g. `1.2.3`). Used as the primary image tag.                                   |
+| `image-name`    | no       | `${{ github.repository }}`  | Image name without registry. Final image is `ghcr.io/<image-name>`.                          |
+| `dockerfile`    | no       | `./Dockerfile`              | Path to the Dockerfile.                                                                      |
+| `build-context` | no       | `.`                         | Docker build context directory.                                                              |
+| `platforms`     | no       | `linux/amd64,linux/arm64`   | Comma-separated target platforms for `buildx`.                                               |
+| `latest`        | no       | `true`                      | Also tag the image as `:latest`. Set to `false` for pre-releases / RCs.                      |
+
+## Secrets
+
+None. Authentication uses the automatically-provided `GITHUB_TOKEN`.
+
+## Required caller permissions
+
+The calling job **must** grant at least these permissions — the reusable workflow declaring them is not enough on its own:
+
+```yaml
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+```
+
+## Usage
+
+```yaml
+name: Release
+on:
+  release:
+    types: [published]
+
+jobs:
+  docker:
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    uses: yonatankarp/github-actions/.github/workflows/release-docker-ghcr.yml@v2
+    with:
+      tag: ${{ github.event.release.tag_name }}
+```
+
+With overrides:
+
+```yaml
+    with:
+      tag: ${{ github.event.release.tag_name }}
+      image-name: yonatankarp/cat-fact-service
+      dockerfile: ./docker/Dockerfile
+      platforms: linux/amd64
+      latest: false
+```
+
+## Notes
+
+- **Package visibility:** GHCR creates packages as **private** on first push. Flip to public in the package settings on GitHub if you want unauthenticated pulls.
+- **Multi-arch build time:** `linux/arm64` is built via QEMU emulation on `ubuntu-latest`, which is 3–5× slower than native. Drop to `linux/amd64` if build time matters more than ARM support.
+- **Provenance:** Build provenance attestation is enabled (`mode=min`) — signed metadata is attached to the image linking it back to the workflow run that built it. SBOM and full `mode=max` provenance are intentionally not enabled.

--- a/.github/workflows/release-docker-ghcr.yml
+++ b/.github/workflows/release-docker-ghcr.yml
@@ -44,35 +44,15 @@ jobs:
       attestations: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-
-      - uses: docker/setup-qemu-action@v3
-
-      - uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
+      - name: Publish to GHCR
+        uses: yonatankarp/github-actions/.github/actions/publish-docker-image@v2
         with:
           registry: ghcr.io
+          image-name: ${{ inputs.image-name }}
+          tag: ${{ inputs.tag }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Compute tags & labels
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ghcr.io/${{ inputs.image-name }}
-          tags: |
-            type=raw,value=${{ inputs.tag }}
-            type=raw,value=latest,enable=${{ inputs.latest }}
-
-      - name: Build & push
-        uses: docker/build-push-action@v6
-        with:
-          context: ${{ inputs.build-context }}
-          file: ${{ inputs.dockerfile }}
+          dockerfile: ${{ inputs.dockerfile }}
+          build-context: ${{ inputs.build-context }}
           platforms: ${{ inputs.platforms }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          provenance: mode=min
+          latest: ${{ inputs.latest }}

--- a/.github/workflows/release-docker-ghcr.yml
+++ b/.github/workflows/release-docker-ghcr.yml
@@ -1,0 +1,78 @@
+name: Release Docker Image to GHCR
+on:
+  workflow_call:
+    inputs:
+      tag:
+        type: string
+        required: true
+        description: the tag of this release (e.g. for SemVer `1.2.3`)
+      image-name:
+        type: string
+        required: false
+        default: ${{ github.repository }}
+        description: |
+          image name without registry, defaults to <owner>/<repo>
+          (final image: ghcr.io/<image-name>)
+      dockerfile:
+        type: string
+        required: false
+        default: ./Dockerfile
+        description: path to the Dockerfile
+      build-context:
+        type: string
+        required: false
+        default: .
+        description: docker build context
+      platforms:
+        type: string
+        required: false
+        default: linux/amd64,linux/arm64
+        description: target platforms for buildx
+      latest:
+        type: boolean
+        required: false
+        default: true
+        description: also tag the image as `:latest`
+
+jobs:
+  image:
+    name: Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute tags & labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ inputs.image-name }}
+          tags: |
+            type=raw,value=${{ inputs.tag }}
+            type=raw,value=latest,enable=${{ inputs.latest }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ inputs.build-context }}
+          file: ${{ inputs.dockerfile }}
+          platforms: ${{ inputs.platforms }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=min


### PR DESCRIPTION
## Summary
- Adds composite action **`.github/actions/publish-docker-image`**: registry-agnostic builder that does checkout → qemu → buildx → login → metadata → multi-arch build+push with provenance attestation. Shared between GHCR and (upcoming) Docker Hub release workflows.
- Adds reusable workflow **`.github/workflows/release-docker-ghcr.yml`**: thin shim that wires GHCR specifics (registry hostname, `github.actor`, `GITHUB_TOKEN`) into the composite. Mirrors the input shape of `release-jar.yml` — caller wires its own trigger.
- Tags with the supplied release `tag` and optionally `:latest` (opt-out via `latest: false` for RCs).
- Provenance attestation on (`mode=min`); SBOM and full `mode=max` intentionally skipped.
- Adjacent READMEs document both the composite action and the workflow.

## Doc convention proposal
This PR establishes the first READMEs in the repo for a composite action and a reusable workflow. Going forward:
- Composite actions: per-folder `README.md` next to `action.yml` (auto-rendered by GitHub).
- Reusable workflows: per-workflow adjacent `.md` file.

Follow-up issue should backfill READMEs for the existing 6 composite actions + 5 workflows.

## Test plan
- [ ] Wire `cat-fact-service` to call `release-docker-ghcr.yml@v2` on release; confirm image is pushed to `ghcr.io/yonatankarp/cat-fact-service:<tag>` and `:latest`.
- [ ] Verify the package shows up under repo packages and the provenance attestation is attached.
- [ ] Confirm `latest: false` skips the `:latest` tag on a pre-release.
- [ ] (Future PR for Docker Hub) confirm the same composite action works against `docker.io` with DH credentials.

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GitHub Actions workflow documentation for publishing Docker images to container registries.

* **Chores**
  * Added automated Docker image publishing workflow with support for multi-architecture builds (linux/amd64, linux/arm64) and configurable image tags and platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yonatankarp/github-actions/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->