### PR TITLE
Backfill READMEs for composite actions and reusable workflows

### DIFF
--- a/.github/actions/build-docker-image/README.md
+++ b/.github/actions/build-docker-image/README.md
@@ -1,0 +1,35 @@
+# `build-docker-image`
+
+Composite action that runs a single-architecture `docker build` against the supplied Dockerfile. Image name is sanitized to lowercase (Docker requires it). Does **not** push — used for CI build-verification only. For release/push, see [`publish-docker-image`](../publish-docker-image).
+
+## Inputs
+
+| Name              | Required | Default       | Description                                                                  |
+|-------------------|----------|---------------|------------------------------------------------------------------------------|
+| `image-name`      | yes      | —             | Docker image name. Sanitized to lowercase for Docker compatibility.          |
+| `dockerfile-path` | yes      | —             | Path to the Dockerfile relative to `build-context`.                          |
+| `build-context`   | no       | `.`           | Docker build context directory.                                              |
+
+## Outputs
+
+None.
+
+## Required caller permissions
+
+None beyond the defaults — the action does not push, log in, or read repository metadata.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@v6
+
+- uses: yonatankarp/github-actions/.github/actions/build-docker-image@v2
+  with:
+    image-name: cat-fact-service
+    dockerfile-path: ./Dockerfile
+```
+
+## Notes
+
+- **Build-only.** Image is built as `<sanitized-name>:latest` on the runner and discarded when the job ends. Use [`publish-docker-image`](../publish-docker-image) to push to a registry.
+- **Single arch.** Builds for the runner's native architecture only. No `buildx`, no QEMU. Add cross-arch builds via `publish-docker-image` instead.

--- a/.github/actions/build-jar-artifact/README.md
+++ b/.github/actions/build-jar-artifact/README.md
@@ -1,0 +1,48 @@
+# `build-jar-artifact`
+
+Composite action that checks out the repo (with submodules), installs the requested JDK, writes the release version into `gradle.properties`, and runs `./gradlew build` — optionally scoped to a single module. Used as the build step inside [`release-jar.yml`](../../workflows/release-jar.yml).
+
+Steps it performs:
+
+1. `actions/checkout@v6` with `submodules: recursive` (token-authenticated).
+2. `actions/setup-java@v5` with Gradle caching.
+3. Writes `version=<tag>` to `gradle.properties`.
+4. Runs `./gradlew build` or `./gradlew :<module>:build`.
+
+## Inputs
+
+| Name               | Required | Default     | Description                                                                                  |
+|--------------------|----------|-------------|----------------------------------------------------------------------------------------------|
+| `tag`              | yes      | —           | Release tag (e.g. `1.2.3`). Written to `gradle.properties` as `version=<tag>`.               |
+| `github-token`     | yes      | —           | Token used for submodule checkout. Pass `${{ secrets.GITHUB_TOKEN }}` or a PAT with the right scopes when private submodules are involved. |
+| `module-name`      | no       | `''`        | Gradle module to build (e.g. `app`). Empty runs the root build.                              |
+| `jvm-version`      | no       | `25`        | JDK major version.                                                                           |
+| `jvm-distribution` | no       | `temurin`   | JDK distribution passed to `actions/setup-java`.                                             |
+
+## Required caller permissions
+
+None beyond what `actions/checkout` and `setup-java` need (typically `contents: read`).
+
+## Usage
+
+```yaml
+- uses: yonatankarp/github-actions/.github/actions/build-jar-artifact@v2
+  with:
+    tag: ${{ github.event.release.tag_name }}
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+With a module and a non-default JDK:
+
+```yaml
+  with:
+    tag: ${{ github.event.release.tag_name }}
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    module-name: app
+    jvm-version: '21'
+```
+
+## Notes
+
+- **Includes checkout.** Unlike most actions in this repo, this one runs `actions/checkout` itself with `submodules: recursive`. Don't double-check-out in the caller.
+- **Submodule access.** If the repo has private submodules, pass a PAT with `repo` scope as `github-token`; the default `GITHUB_TOKEN` cannot read other private repos.

--- a/.github/actions/detect-source-changes/README.md
+++ b/.github/actions/detect-source-changes/README.md
@@ -1,0 +1,49 @@
+# `detect-source-changes`
+
+Composite action that wraps [`dorny/paths-filter`](https://github.com/dorny/paths-filter) with a curated filter for the standard JVM/Gradle source set plus an optional Dockerfile. Emits a single boolean output `source_code` so downstream steps can short-circuit when nothing build-relevant changed.
+
+Files that count as a source change:
+
+- `.github/workflows/**`
+- `.github/actions/**`
+- `**/src/**`
+- `**/build.gradle.kts`
+- `gradle/libs.versions.toml`
+- `gradle/wrapper/gradle-wrapper.properties`
+- `gradlew`, `gradlew.bat`, `settings.gradle.kts`
+- The supplied `dockerfile-path`, if any.
+
+## Inputs
+
+| Name              | Required | Default | Description                                                                                  |
+|-------------------|----------|---------|----------------------------------------------------------------------------------------------|
+| `dockerfile-path` | no       | `''`    | Optional Dockerfile path to include in the filter. Leave empty if the repo has no Dockerfile.|
+
+## Outputs
+
+| Name          | Description                                                            |
+|---------------|------------------------------------------------------------------------|
+| `source_code` | `'true'` if any path matched the filter, `'false'` otherwise.          |
+
+## Required caller permissions
+
+None.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@v6
+
+- id: changes
+  uses: yonatankarp/github-actions/.github/actions/detect-source-changes@v2
+  with:
+    dockerfile-path: ./Dockerfile
+
+- if: steps.changes.outputs.source_code == 'true'
+  run: ./gradlew build
+```
+
+## Notes
+
+- **Output is a string.** GitHub Actions outputs are always strings — compare against `'true'` (with quotes), not the boolean `true`.
+- **Caller must check out first.** `paths-filter` runs against the working tree; check out the repo before this step.

--- a/.github/actions/gradle-build/README.md
+++ b/.github/actions/gradle-build/README.md
@@ -1,0 +1,35 @@
+# `gradle-build`
+
+Composite action that runs `./gradlew build`, optionally scoped to a single Gradle module path.
+
+Assumes the consumer has already checked out the repo and run [`prepare-jvm-build`](../prepare-jvm-build) (or equivalent JDK + Gradle setup).
+
+## Inputs
+
+| Name            | Required | Default | Description                                                              |
+|-----------------|----------|---------|--------------------------------------------------------------------------|
+| `gradle-module` | no       | `''`    | Gradle module (e.g. `:app`, `:nested:module`). Empty runs the root task. |
+
+## Required caller permissions
+
+None.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@v6
+- uses: yonatankarp/github-actions/.github/actions/prepare-jvm-build@v2
+- uses: yonatankarp/github-actions/.github/actions/gradle-build@v2
+```
+
+For a specific module:
+
+```yaml
+- uses: yonatankarp/github-actions/.github/actions/gradle-build@v2
+  with:
+    gradle-module: ':app'
+```
+
+## Notes
+
+- **Module syntax.** Use Gradle's colon-prefixed path (e.g. `:app`, `:skeletons:spring`). Bare names without the leading `:` won't resolve.

--- a/.github/actions/prepare-jvm-build/README.md
+++ b/.github/actions/prepare-jvm-build/README.md
@@ -1,0 +1,44 @@
+# `prepare-jvm-build`
+
+Composite action that validates the Gradle wrapper, installs the requested JDK, and sets up Gradle with shared caching. The standard pre-build step for any JVM workflow in this repo.
+
+Steps it performs:
+
+1. `gradle/actions/wrapper-validation@v6` — verifies `gradle-wrapper.jar` against the Gradle wrapper checksum database.
+2. `actions/setup-java@v5` with the requested distribution + version.
+3. `gradle/actions/setup-gradle@v6` with the build cache. Read-only cache off `main`; read-write on `main`.
+
+**Assumes the consumer has already checked out the repo.**
+
+## Inputs
+
+| Name               | Required | Default     | Description                                                                                  |
+|--------------------|----------|-------------|----------------------------------------------------------------------------------------------|
+| `jvm-version`      | no       | `25`        | JDK major version (e.g. `21`, `25`).                                                         |
+| `jvm-distribution` | no       | `temurin`   | JDK distribution: `temurin`, `zulu`, `microsoft`, `corretto`, `semeru`, `graalvm`.           |
+
+## Required caller permissions
+
+None.
+
+## Usage
+
+```yaml
+- uses: actions/checkout@v6
+
+- uses: yonatankarp/github-actions/.github/actions/prepare-jvm-build@v2
+```
+
+With overrides:
+
+```yaml
+- uses: yonatankarp/github-actions/.github/actions/prepare-jvm-build@v2
+  with:
+    jvm-version: '21'
+    jvm-distribution: zulu
+```
+
+## Notes
+
+- **Cache scope.** Build cache is read-write only on `refs/heads/main`. Feature branches read the cache but cannot poison it.
+- **Caller must check out first.** Wrapper validation needs `gradle/wrapper/gradle-wrapper.jar` to exist on disk.

--- a/.github/actions/publish-test-reports/README.md
+++ b/.github/actions/publish-test-reports/README.md
@@ -1,0 +1,51 @@
+# `publish-test-reports`
+
+Composite action that publishes JUnit results as a GitHub Check and uploads HTML test reports + JaCoCo coverage as workflow artifacts. Both steps use `if: always()` so they run even when the build fails (so red builds still get reports).
+
+Steps it performs:
+
+1. `EnricoMi/publish-unit-test-result-action@v2` — turns JUnit XML into a Check.
+2. `actions/upload-artifact@v7` — uploads `**/build/reports/tests/**` and `**/build/reports/jacoco/test/**`.
+
+## Inputs
+
+| Name             | Required | Default                                       | Description                                                                                  |
+|------------------|----------|-----------------------------------------------|----------------------------------------------------------------------------------------------|
+| `junit-pattern`  | no       | `**/build/test-results/test/TEST-*.xml`       | Glob for JUnit XML files.                                                                    |
+| `artifact-name`  | no       | `test-reports`                                | Name of the uploaded artifact bundle.                                                        |
+| `check-name`     | no       | `Test Results`                                | Name of the GitHub Check. Pass a unique value per matrix variant to avoid clobbering.        |
+
+## Required caller permissions
+
+The calling job **must** grant:
+
+```yaml
+permissions:
+  pull-requests: write
+  checks: write
+```
+
+Without these, `publish-unit-test-result-action` cannot create the Check.
+
+## Usage
+
+```yaml
+- if: always()
+  uses: yonatankarp/github-actions/.github/actions/publish-test-reports@v2
+```
+
+In a matrix build, give each variant a unique check name so they don't overwrite each other:
+
+```yaml
+- if: always()
+  uses: yonatankarp/github-actions/.github/actions/publish-test-reports@v2
+  with:
+    check-name: Test Results (${{ matrix.variant }})
+    artifact-name: test-reports-${{ matrix.variant }}
+```
+
+## Notes
+
+- **Always-run.** Both inner steps use `if: always()`, but the action itself only runs if the caller's `if:` lets it. Wrap the caller step with `if: always()` to publish even on failure.
+- **Unique names in matrices.** Duplicate `check-name` values across matrix legs cause the last-finishing leg to clobber the others' Check. Same for `artifact-name`.
+- **`pull-requests: write` requirement** comes from `publish-unit-test-result-action`, which posts a PR comment with the summary in addition to the Check.

--- a/.github/workflows/ci.md
+++ b/.github/workflows/ci.md
@@ -1,0 +1,71 @@
+# `ci.yml`
+
+Reusable JVM CI workflow. Chains the repo's composite actions into the standard build pipeline:
+
+1. `actions/checkout@v6` (optionally with submodules).
+2. [`prepare-jvm-build`](../actions/prepare-jvm-build) — wrapper validation, JDK install, Gradle setup.
+3. [`detect-source-changes`](../actions/detect-source-changes) — short-circuit when nothing build-relevant changed.
+4. [`gradle-build`](../actions/gradle-build) — runs `./gradlew build` (or scoped to a module). **Skipped when no source changes.**
+5. [`publish-test-reports`](../actions/publish-test-reports) — JUnit Check + HTML/JaCoCo artifacts. Runs with `if: always()` to publish on red builds. **Disable via `publish-test-reports: false`.**
+6. [`build-docker-image`](../actions/build-docker-image) — only runs when `dockerfile-path` is set _and_ source changed.
+
+## Inputs
+
+| Name                   | Required | Default                              | Description                                                                                  |
+|------------------------|----------|--------------------------------------|----------------------------------------------------------------------------------------------|
+| `jvm-version`          | no       | `'25'`                               | JDK major version.                                                                           |
+| `jvm-distribution`     | no       | `'temurin'`                          | JDK distribution passed to `actions/setup-java`.                                             |
+| `gradle-module`        | no       | `''`                                 | Gradle module path (e.g. `:app`). Empty runs the root build.                                 |
+| `dockerfile-path`      | no       | `''`                                 | Path to the Dockerfile. Empty disables the docker build step.                                |
+| `image-name`           | no       | `${{ github.event.repository.name }}`| Docker image name (sanitized to lowercase by `build-docker-image`).                          |
+| `publish-test-reports` | no       | `true`                               | Publish the JUnit Check + upload test/coverage artifacts.                                    |
+| `submodules`           | no       | `'false'`                            | Forwarded to `actions/checkout`. Accepts `'false'`, `'true'`, or `'recursive'` (as string).  |
+
+## Secrets
+
+None — uses the auto-provided `GITHUB_TOKEN`.
+
+## Required caller permissions
+
+The reusable workflow declares these on its inner job, but the calling workflow must allow at least:
+
+```yaml
+permissions:
+  contents: read
+  pull-requests: write
+  checks: write
+```
+
+`pull-requests: write` + `checks: write` are only needed when `publish-test-reports: true` (the default).
+
+## Usage
+
+Minimal:
+
+```yaml
+name: CI
+on:
+  pull_request:
+
+jobs:
+  build:
+    uses: yonatankarp/github-actions/.github/workflows/ci.yml@v2
+```
+
+With a Dockerfile and a specific module:
+
+```yaml
+jobs:
+  build:
+    uses: yonatankarp/github-actions/.github/workflows/ci.yml@v2
+    with:
+      gradle-module: ':app'
+      dockerfile-path: ./Dockerfile
+      image-name: cat-fact-service
+```
+
+## Notes
+
+- **Build skipped without source changes.** `detect-source-changes` decides whether `gradle-build` and `build-docker-image` run. Doc-only changes therefore skip the build path but still publish (empty) test reports.
+- **`submodules` is a string, not a boolean.** `actions/checkout` accepts `false` / `true` / `recursive`; we pass it through unchanged. Type is `string` for that reason.
+- **Image name is sanitized.** `build-docker-image` lowercases the image name before tagging, so `image-name: KTOR-SKELETON` builds `ktor-skeleton:latest`.

--- a/.github/workflows/dependabot-auto-merge.md
+++ b/.github/workflows/dependabot-auto-merge.md
@@ -1,0 +1,68 @@
+# `dependabot-auto-merge.yml`
+
+Reusable workflow that auto-approves and auto-merges Dependabot PRs for **semver-minor and semver-patch** updates, optionally moving a floating major tag (e.g. `v2`) to the post-merge SHA.
+
+Behavior:
+
+1. Fetch Dependabot metadata for the PR.
+2. Approve the PR (only for minor/patch updates).
+3. Wait for all required status checks to pass.
+4. `gh pr merge --admin --rebase`.
+5. _(optional)_ Run the tagging script to move `v2` to the new merge commit.
+
+**Major-version bumps are intentionally _not_ auto-merged** — they need a human eye.
+
+The `if: github.actor == 'dependabot[bot]'` guard means this job is a no-op on non-Dependabot PRs; safe to wire into a generic CI pipeline (see [`ouroboros.yml`](./ouroboros.md) for the in-repo example).
+
+## Inputs
+
+| Name                  | Required | Default                  | Description                                                                                  |
+|-----------------------|----------|--------------------------|----------------------------------------------------------------------------------------------|
+| `auto-update-tag`     | no       | `false`                  | When `true`, run `tagging-script-path` after a successful merge to move `v2` to the new SHA. |
+| `tagging-script-path` | no       | `./bin/replace-tags.sh`  | Path to the tagging script inside the consumer repo.                                         |
+
+## Secrets
+
+| Name         | Required | Description                                                                                                       |
+|--------------|----------|-------------------------------------------------------------------------------------------------------------------|
+| `GITHUB_PAT` | yes      | PAT that can **approve** and **merge** PRs. The default `GITHUB_TOKEN` can't approve PRs created by `dependabot[bot]`. |
+
+## Required caller permissions
+
+```yaml
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+`contents: write` is needed for the tag-moving step. `pull-requests: write` lets `gh` operate on the PR.
+
+## Usage
+
+In the consumer repo's CI workflow:
+
+```yaml
+jobs:
+  dependabot:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v2
+    secrets:
+      GITHUB_PAT: ${{ secrets.CI_PAT }}
+```
+
+With floating-tag updates enabled (used by the workflows-repo itself to keep `v2` current):
+
+```yaml
+    with:
+      auto-update-tag: true
+```
+
+## Notes
+
+- **PAT, not `GITHUB_TOKEN`.** Dependabot PRs can't be approved by the same user (the bot is the author), and the default `GITHUB_TOKEN` lacks the cross-actor approval permission. A PAT (or fine-grained token with `pull_requests: write` + `contents: write`) is required.
+- **Status-check wait.** `gh pr checks --watch --required` polls until all required checks complete. If a required check hangs, this job will sit idle until the runner times out — set the calling job's `timeout-minutes` accordingly.
+- **Concurrency.** The workflow declares `concurrency: group: <workflow>-<ref>`. Repeated invocations on the same PR replace the previous run.
+- **Major bumps are skipped.** The `if:` condition only matches `version-update:semver-minor` and `version-update:semver-patch`. Other update types fall through without approval or merge.

--- a/.github/workflows/linters.md
+++ b/.github/workflows/linters.md
@@ -1,0 +1,61 @@
+# `linters.yml`
+
+Reusable workflow that runs documentation and code-style linters in parallel-ish fashion:
+
+1. `markdown-lint` over all `**/*.md` (when `docs/**` or `README.md` changed).
+2. `./gradlew spotlessCheck` (when source-set files changed).
+
+Each linter can be disabled independently via inputs. Both run inside the same job, gated by a [`dorny/paths-filter`](https://github.com/dorny/paths-filter) step to skip work when nothing relevant changed.
+
+Markdown rules come from a bundled `config/markdown-lint/rules.json` (fetched at runtime from the `v2` tag of this repo) unless the caller overrides the path.
+
+## Inputs
+
+| Name                   | Required | Default     | Description                                                                                  |
+|------------------------|----------|-------------|----------------------------------------------------------------------------------------------|
+| `check_docs`           | no       | `true`      | Run `markdown-lint`.                                                                         |
+| `check_style`          | no       | `true`      | Run `spotlessCheck`.                                                                         |
+| `jvm-version`          | no       | `'25'`      | JDK version used to run `spotlessCheck`. Only matters when `check_style: true`.              |
+| `jvm-distribution`     | no       | `'temurin'` | JDK distribution.                                                                            |
+| `markdown-lint-config` | no       | `''`        | Path to a `rules.json` inside the consumer repo. Empty fetches the repo's bundled defaults.  |
+
+## Secrets
+
+None — uses the auto-provided `GITHUB_TOKEN`.
+
+## Required caller permissions
+
+```yaml
+permissions:
+  contents: read
+```
+
+## Usage
+
+Minimal:
+
+```yaml
+jobs:
+  lint:
+    uses: yonatankarp/github-actions/.github/workflows/linters.yml@v2
+```
+
+Docs-only repo (skip spotless):
+
+```yaml
+    with:
+      check_style: false
+```
+
+With a custom markdown-lint config:
+
+```yaml
+    with:
+      markdown-lint-config: ./.markdownlint.json
+```
+
+## Notes
+
+- **Input naming.** `check_docs` and `check_style` are snake_case (unlike most other inputs in this repo) for historical reasons; kebab-case breaks GH Actions matrix-key parsing in some contexts.
+- **Dependabot checkout.** When the actor is `dependabot[bot]`, the workflow checks out `${{ github.event.pull_request.head.sha }}` instead of the default ref — necessary because Dependabot PRs run with a restricted `GITHUB_TOKEN` and the default checkout can fail.
+- **Bundled rules are tag-pinned.** The default markdown-lint config is fetched from `raw.githubusercontent.com/yonatankarp/github-actions/v2/...`. If the floating `v2` tag is moved, the rules change. Pin via `markdown-lint-config` for stability.

--- a/.github/workflows/ouroboros.md
+++ b/.github/workflows/ouroboros.md
@@ -1,0 +1,39 @@
+# `ouroboros.yml`
+
+**This workflow is _not_ a reusable workflow.** It is the in-repo CI that tests this repo's own reusable workflows and composite actions against the bundled skeleton projects under `skeletons/`. Named after [Ouroboros](https://en.wikipedia.org/wiki/Ouroboros) — the serpent eating its tail — because it uses the workflows-repo to test the workflows-repo.
+
+Triggered on `pull_request` (`opened`, `synchronize`, `reopened`, `ready_for_review`).
+
+## What it runs
+
+| Job                  | Purpose                                                                                                              |
+|----------------------|----------------------------------------------------------------------------------------------------------------------|
+| `pipeline`           | Matrix call to [`ci.yml`](./ci.md) across 4 variants (spring/ktor skeletons, with/without Docker, with submodule).   |
+| `dependabot_auto_merge` | Calls [`dependabot-auto-merge.yml`](./dependabot-auto-merge.md) when the PR author is `dependabot[bot]`.          |
+| `linters`            | Calls [`linters.yml`](./linters.md).                                                                                 |
+| `actions-linter`     | Runs `devops-actions/actionlint` against the workflow YAMLs.                                                         |
+| `all-green`          | Aggregates `pipeline`, `linters`, `actions-linter` into a single required check via `re-actors/alls-green`.          |
+
+## Matrix variants tested by `pipeline`
+
+| Variant                       | `image_name`     | `dockerfile_path`              | `gradle_module`     | Why                                          |
+|-------------------------------|------------------|--------------------------------|---------------------|----------------------------------------------|
+| `spring-skeleton`             | `spring-skeleton`| `skeletons/spring/Dockerfile`  | _(root)_            | Baseline Spring build.                       |
+| `ktor-skeleton-uppercase`     | `KTOR-SKELETON`  | `skeletons/ktor/Dockerfile`    | _(root)_            | Exercises the lowercase-sanitization path.   |
+| `spring-skeleton-no-docker`   | `spring-skeleton`| _(empty)_                      | _(root)_            | Confirms the Docker step is skipped.         |
+| `spring-skeleton-submodule`   | `spring-skeleton`| `skeletons/spring/Dockerfile`  | `:skeletons:spring` | Confirms module-scoped builds work.          |
+
+## Permissions
+
+Top-level grants `contents: write` (needed by `dependabot_auto_merge` for tag-moving). Each job tightens the scope further as needed.
+
+## Secrets used
+
+- `CI_PAT` — passed to `dependabot_auto_merge` as `GITHUB_PAT`. Set this in repo secrets.
+
+## Notes
+
+- **Not callable.** This workflow has no `workflow_call` trigger; do not try to `uses:` it from another repo.
+- **Local `uses: ./...`.** Sub-jobs reference `./.github/workflows/ci.yml` etc. — the local files, not the published `@v2` tag. That's intentional: the point is to test the in-progress branch, not the released version.
+- **`all-green` is the only required check.** Set repo branch-protection to require `all-green` and skip the individual sub-jobs.
+- **Concurrency.** `<workflow>-<job>-<ref>` with `cancel-in-progress: true` — pushing a new commit to a PR cancels the previous run.

--- a/.github/workflows/release-jar.md
+++ b/.github/workflows/release-jar.md
@@ -1,0 +1,53 @@
+# `release-jar.yml`
+
+Reusable workflow that builds a JAR artifact and publishes it to **GitHub Packages** (Maven). The caller wires its own trigger (typically `release: types: [published]` or a tag-push).
+
+Internally delegates to the [`build-jar-artifact`](../actions/build-jar-artifact) composite action and then runs `./gradlew publishMavenPublicationToGitHubPackagesRepository`.
+
+## Inputs
+
+| Name           | Required | Default | Description                                                                                  |
+|----------------|----------|---------|----------------------------------------------------------------------------------------------|
+| `tag`          | yes      | —       | Release tag (e.g. `1.2.3`). Used as the published artifact version.                          |
+| `module-name`  | no       | `''`    | Gradle module to build/publish. Empty assumes a single-module (non-modular) project.         |
+
+## Secrets
+
+| Name           | Required | Description                                                                                  |
+|----------------|----------|----------------------------------------------------------------------------------------------|
+| `github-token` | yes      | PAT with `write:packages` (and `repo` for private repos) — used for submodule checkout _and_ as the credential the Gradle plugin uses to publish to GitHub Packages. |
+
+## Required caller permissions
+
+The reusable workflow handles its own auth via the passed-in secret, so the caller's `permissions:` block needs no extras beyond the default `contents: read`.
+
+## Usage
+
+```yaml
+name: Release
+on:
+  release:
+    types: [published]
+
+jobs:
+  jar:
+    uses: yonatankarp/github-actions/.github/workflows/release-jar.yml@v2
+    with:
+      tag: ${{ github.event.release.tag_name }}
+    secrets:
+      github-token: ${{ secrets.PUBLISH_PACKAGES_PAT }}
+```
+
+Multi-module project:
+
+```yaml
+    with:
+      tag: ${{ github.event.release.tag_name }}
+      module-name: app
+```
+
+## Notes
+
+- **`GITHUB_TOKEN` is _not_ sufficient.** GitHub Packages publishing across repos requires a PAT (or fine-grained token) with `write:packages`. The default `GITHUB_TOKEN` works only for publishing into the same repo — and not at all for submodule checkout into private repos.
+- **Version comes from the input.** `build-jar-artifact` writes `version=<tag>` into `gradle.properties` before the build; the Gradle publish plugin picks that up. Don't override `version` in your `build.gradle.kts` if you want this to work.
+- **Submodules supported.** `build-jar-artifact` checks out with `submodules: recursive` using the same `github-token`. Make sure that token can read the submodule repos.


### PR DESCRIPTION
## Summary
Backfills docs for the 11 composite actions and reusable workflows that pre-dated the README convention established in #126.

**Composite actions (6 new READMEs):**
- \`build-docker-image\`
- \`build-jar-artifact\`
- \`detect-source-changes\`
- \`gradle-build\`
- \`prepare-jvm-build\`
- \`publish-test-reports\`

**Workflows (5 new READMEs):**
- \`ci.md\`
- \`dependabot-auto-merge.md\`
- \`linters.md\`
- \`ouroboros.md\` — special-cased; it's the in-repo CI, not a \`workflow_call\` reusable, so the doc covers matrix variants + the \`all-green\` aggregation instead of inputs.
- \`release-jar.md\`

## Template
Each doc follows the shape established in #126:
- Summary + steps performed
- Inputs table (name / required / default / description)
- Secrets table (when any)
- Required caller permissions
- Minimal usage example + at least one with overrides
- Notes / gotchas (only real ones — submodule scope, sanitization, \`GITHUB_TOKEN\` vs PAT, etc.)

## Conventions confirmed
- Composite actions: per-folder \`README.md\` next to \`action.yml\` (auto-rendered on GitHub).
- Reusable workflows: per-workflow adjacent \`.md\` file using the workflow's basename (e.g. \`ci.md\` next to \`ci.yml\`).

## Test plan
- [ ] Eyeball each README on the PR's Files Changed tab — check tables render, intra-repo links resolve.
- [ ] Click through the relative links between docs (e.g. \`ci.md\` → \`prepare-jvm-build\`, \`ouroboros.md\` → \`ci.md\`).
- [ ] Confirm \`README.md\` files render automatically when browsing each \`.github/actions/<name>/\` folder on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)