### PR TITLE
Retire dead tag-move logic from dependabot-auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.md
+++ b/.github/workflows/dependabot-auto-merge.md
@@ -1,6 +1,6 @@
 # `dependabot-auto-merge.yml`
 
-Reusable workflow that auto-approves and auto-merges Dependabot PRs for **semver-minor and semver-patch** updates, optionally moving a floating major tag (e.g. `v2`) to the post-merge SHA.
+Reusable workflow that auto-approves and auto-merges Dependabot PRs for **semver-minor and semver-patch** updates.
 
 Behavior:
 
@@ -8,18 +8,16 @@ Behavior:
 2. Approve the PR (only for minor/patch updates).
 3. Wait for all required status checks to pass.
 4. `gh pr merge --admin --rebase`.
-5. _(optional)_ Run the tagging script to move `v2` to the new merge commit.
 
 **Major-version bumps are intentionally _not_ auto-merged** — they need a human eye.
 
 The `if: github.actor == 'dependabot[bot]'` guard means this job is a no-op on non-Dependabot PRs; safe to wire into a generic CI pipeline (see [`ouroboros.yml`](./ouroboros.md) for the in-repo example).
 
+Floating-tag moves (e.g. advancing `v2` after a merge) are handled separately by [`move-major-tag.yml`](./move-major-tag.md), which runs on every push to `main` regardless of author.
+
 ## Inputs
 
-| Name                  | Required | Default                  | Description                                                                                  |
-|-----------------------|----------|--------------------------|----------------------------------------------------------------------------------------------|
-| `auto-update-tag`     | no       | `false`                  | When `true`, run `tagging-script-path` after a successful merge to move `v2` to the new SHA. |
-| `tagging-script-path` | no       | `./bin/replace-tags.sh`  | Path to the tagging script inside the consumer repo.                                         |
+None.
 
 ## Secrets
 
@@ -31,11 +29,11 @@ The `if: github.actor == 'dependabot[bot]'` guard means this job is a no-op on n
 
 ```yaml
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 ```
 
-`contents: write` is needed for the tag-moving step. `pull-requests: write` lets `gh` operate on the PR.
+`pull-requests: write` lets `gh` operate on the PR via the PAT.
 
 ## Usage
 
@@ -46,18 +44,11 @@ jobs:
   dependabot:
     if: ${{ github.actor == 'dependabot[bot]' }}
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v2
     secrets:
       GITHUB_PAT: ${{ secrets.CI_PAT }}
-```
-
-With floating-tag updates enabled (used by the workflows-repo itself to keep `v2` current):
-
-```yaml
-    with:
-      auto-update-tag: true
 ```
 
 ## Notes

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -2,29 +2,15 @@
 name: Dependabot auto-merge
 on:
   workflow_call:
-    inputs:
-      auto-update-tag:
-        type: boolean
-        description: Whether to run the tagging-script-path script to move the repository tag after a successful merge.
-        default: false
-        required: false
-      tagging-script-path:
-        type: string
-        description: Path to the tagging script to execute after a successful merge.
-        required: false
-        default: ./bin/replace-tags.sh
     secrets:
       GITHUB_PAT:
         description: "Token that can approve and merge pull requests."
         required: true
 
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
 
-# The latest build tags the produced image with `latest` (or `pr-N` for PRs) tag. Concurrent builds can potentially cause
-# inconsistency, e.g., when an older build finishes after the latest build. Currently, such inconsistency is still
-# possible when an older build is replayed.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 
@@ -32,16 +18,7 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
-    env:
-      TAG_VERSION: v2
     steps:
-      - name: Dependabot Checkout
-        if: ${{ inputs.auto-update-tag == true }}
-        uses: actions/checkout@v6
-        with:
-          submodules: 'recursive'
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v3
@@ -70,11 +47,3 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_PAT }}
         run: gh pr merge --admin --rebase "$PR_URL"
-
-      - name: Move tag to current commit
-        if: ${{ inputs.auto-update-tag == true && (steps.metadata.outputs.update-type
-          == 'version-update:semver-minor' || steps.metadata.outputs.update-type
-          == 'version-update:semver-patch') }}
-        env:
-          TAGGING_SCRIPT: ${{ inputs.tagging-script-path }}
-        run: sh "$TAGGING_SCRIPT" "$TAG_VERSION"

--- a/.github/workflows/move-major-tag.md
+++ b/.github/workflows/move-major-tag.md
@@ -6,7 +6,7 @@ Triggered on `push` to `main`. Internally runs [`bin/replace-tags.sh v2`](../../
 
 ## Why this exists
 
-Before this workflow, `v2` was only auto-moved by [`dependabot-auto-merge.yml`](./dependabot-auto-merge.md) (which runs the same script after a Dependabot merge). Human-authored PRs left `v2` stale — consumers wouldn't see changes until the next Dependabot bump. This workflow closes that gap by moving `v2` on **every** merge to `main`, regardless of who authored it.
+Before this workflow, `v2` was only auto-moved after Dependabot merges, so human-authored PRs left `v2` stale until the next minor/patch bump. This workflow moves `v2` on **every** merge to `main`, regardless of author, and is now the sole owner of that responsibility.
 
 ## What it does
 
@@ -34,6 +34,5 @@ If two pushes to `main` happen in quick succession, the second cancels the first
 
 ## Notes
 
-- **Race with `dependabot-auto-merge`.** For Dependabot merges, _both_ this workflow and the legacy tag-move step in `dependabot-auto-merge.yml` will fire. They produce the same outcome, so the race is harmless, but the legacy step is now redundant and could be retired in a follow-up.
 - **`GITHUB_TOKEN`-authored pushes don't trigger workflows.** Moving `v2` via this workflow won't recurse — GitHub deliberately skips workflow triggers for pushes made with the default token, which is exactly the behavior we want here. (Tag pushes don't match `branches: [main]` anyway.)
 - **First-time setup on a fork.** `actions/checkout@v6` configures git push to use `GITHUB_TOKEN`. With `contents: write`, the token has tag delete + create rights — no PAT needed.

--- a/.github/workflows/ouroboros.md
+++ b/.github/workflows/ouroboros.md
@@ -25,7 +25,7 @@ Triggered on `pull_request` (`opened`, `synchronize`, `reopened`, `ready_for_rev
 
 ## Permissions
 
-Top-level grants `contents: write` (needed by `dependabot_auto_merge` for tag-moving). Each job tightens the scope further as needed.
+Top-level grants `contents: read`. Each job further declares its own scopes (e.g. `pull-requests: write`, `checks: write`) as needed.
 
 ## Secrets used
 

--- a/.github/workflows/ouroboros.yml
+++ b/.github/workflows/ouroboros.yml
@@ -9,7 +9,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   pipeline:
@@ -49,10 +49,8 @@ jobs:
     if: ${{ github.actor == 'dependabot[bot]' }}
     uses: ./.github/workflows/dependabot-auto-merge.yml
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
-    with:
-      auto-update-tag: true
     secrets:
       GITHUB_PAT: ${{ secrets.CI_PAT }}
 


### PR DESCRIPTION
## Summary
\`move-major-tag.yml\` (#128) now owns the floating-\`v2\` move on every push to \`main\`, so the duplicate logic in \`dependabot-auto-merge.yml\` is dead code and was racing with the new workflow on Dependabot merges. This PR removes it.

### Changes

**\`dependabot-auto-merge.yml\`**
- Drop \`auto-update-tag\` and \`tagging-script-path\` inputs (no longer used by anyone).
- Drop the conditional \`Dependabot Checkout\` step (only existed to support the tag-move).
- Drop the \`Move tag to current commit\` step.
- Drop the unused \`TAG_VERSION: v2\` env and a stale build-tag comment that referenced \`latest\`/\`pr-N\` (copy-paste leftover, never applied to this workflow).
- Tighten \`contents\` permission from \`write\` → \`read\` (no longer touches refs).

**\`ouroboros.yml\`**
- Drop the now-invalid \`with: auto-update-tag: true\` on the \`dependabot_auto_merge\` job.
- Tighten top-level + dependabot_auto_merge job \`contents\` permission to \`read\`.

**READMEs**
- \`dependabot-auto-merge.md\`: removed input rows + the \"floating-tag updates\" example; added a sentence pointing at \`move-major-tag.yml\` for tag handling.
- \`move-major-tag.md\`: removed the \"Race with dependabot-auto-merge\" note now that the race is gone.
- \`ouroboros.md\`: updated the permissions note.

Net diff: **+12 / -55 lines.**

## Breaking change
The \`auto-update-tag\` and \`tagging-script-path\` inputs on \`dependabot-auto-merge.yml@v2\` are removed. Any external caller passing them will fail at \`workflow_call\` input validation as soon as \`v2\` is moved (which happens automatically on merge). Recovery: drop the \`with:\` block and add a local \`move-major-tag.yml\`-style workflow if floating-tag moves are wanted.

I'm not aware of any external caller using these inputs — they were only used by \`ouroboros.yml\`, which is updated in this PR.

## Test plan
- [ ] Confirm \`ouroboros.yml\` still passes against this branch (the \`pipeline\`, \`linters\`, \`actions-linter\` jobs).
- [ ] Next Dependabot PR: confirm it still auto-approves + merges minor/patch updates.
- [ ] Confirm \`v2\` advances to this PR's merge commit (single move, no race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)