### PR TITLE
Scope dependabot-auto-merge concurrency group to fix self-deadlock

### DIFF
--- a/.github/workflows/dependabot-auto-merge.md
+++ b/.github/workflows/dependabot-auto-merge.md
@@ -55,5 +55,5 @@ jobs:
 
 - **PAT, not `GITHUB_TOKEN`.** Dependabot PRs can't be approved by the same user (the bot is the author), and the default `GITHUB_TOKEN` lacks the cross-actor approval permission. A PAT (or fine-grained token with `pull_requests: write` + `contents: write`) is required.
 - **Status-check wait.** `gh pr checks --watch --required` polls until all required checks complete. If a required check hangs, this job will sit idle until the runner times out — set the calling job's `timeout-minutes` accordingly.
-- **Concurrency.** The workflow declares `concurrency: group: <workflow>-<ref>`. Repeated invocations on the same PR replace the previous run.
+- **Concurrency.** The workflow declares `concurrency: group: dependabot-auto-merge-<workflow>-<ref>`. The `dependabot-auto-merge-` prefix keeps this distinct from any group the caller may already hold on `<workflow>-<ref>` — without it, the caller and this reusable workflow self-deadlock on the same key and GitHub cancels the job. Repeated invocations on the same PR still replace the previous run.
 - **Major bumps are skipped.** The `if:` condition only matches `version-update:semver-minor` and `version-update:semver-patch`. Other update types fall through without approval or merge.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: dependabot-auto-merge-${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   dependabot:


### PR DESCRIPTION
## Summary

- `dependabot-auto-merge.yml`'s concurrency group was `${{ github.workflow }}-${{ github.ref }}`, which inside a called workflow resolves to the **caller's** workflow name. Consumers using the canonical default (same key in their top-level `concurrency:` block) self-deadlock with this reusable workflow and GitHub cancels the auto-merge job.
- Fixed by prefixing the group with `dependabot-auto-merge-` so it can't collide with a caller's default group key.
- Updated `dependabot-auto-merge.md` to spell out the failure mode so the next person doesn't rediscover it.

## Repro / discovery

In `yonatankarp/ktor-template` (PR [#29](https://github.com/yonatankarp/ktor-template/pull/29) — Dependabot kotest 6.1.2 → 6.1.11), the build job ran green and every visible check-run reported success, but the workflow run was marked `failure`. The `dependabot_auto_merge` job was missing from the REST jobs API entirely; only the workflow-graph HTML exposed it as red. The actual error surfaced from the run page:

> Canceling since a deadlock was detected for concurrency group: 'Continuous Integration-refs/pull/29/merge' between a top level workflow and 'dependabot_auto_merge'

The pipeline reusable workflow (`ci.yml`) doesn't trip this because it doesn't declare its own `concurrency:` block.

## Test plan

- [ ] Merge → `move-major-tag.yml` re-points `v2` to the new HEAD.
- [ ] `@dependabot recreate` on `yonatankarp/ktor-template#29` (consumer still pinned to `@v2`) — verify the recreated run's `dependabot_auto_merge` job runs end-to-end instead of being canceled at dispatch.
- [ ] Confirm `gh api repos/yonatankarp/ktor-template/actions/runs/<id> --jq .conclusion` returns `success` once auto-merge completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Dependabot auto-merge workflow's concurrency group configuration to include a `dependabot-auto-merge` prefix, preventing potential deadlock issues with concurrent workflow executions on the same pull request.

* **Documentation**
  * Updated workflow documentation to reflect the concurrency group naming convention changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yonatankarp/github-actions/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->