### PR TITLE
Make Dependabot auto-merge work with rulesets

### DIFF
--- a/.github/workflows/dependabot-auto-merge.md
+++ b/.github/workflows/dependabot-auto-merge.md
@@ -6,8 +6,7 @@ Behavior:
 
 1. Fetch Dependabot metadata for the PR.
 2. Approve the PR (only for minor/patch updates).
-3. Wait for all required status checks to pass.
-4. `gh pr merge --admin --rebase`.
+3. `gh pr merge --admin --rebase`.
 
 **Major-version bumps are intentionally _not_ auto-merged** — they need a human eye.
 
@@ -54,6 +53,6 @@ jobs:
 ## Notes
 
 - **PAT, not `GITHUB_TOKEN`.** Dependabot PRs can't be approved by the same user (the bot is the author), and the default `GITHUB_TOKEN` lacks the cross-actor approval permission. A PAT (or fine-grained token with `pull_requests: write` + `contents: write`) is required.
-- **Status-check wait.** `gh pr checks --watch --required` polls until all required checks complete. If a required check hangs, this job will sit idle until the runner times out — set the calling job's `timeout-minutes` accordingly.
+- **Validation ordering.** The caller must put this workflow behind its validation jobs with `needs:`. The reusable workflow does not call `gh pr checks --required` because rulesets can report required checks differently from classic branch protection.
 - **Concurrency.** The workflow declares `concurrency: group: dependabot-auto-merge-<workflow>-<ref>`. The `dependabot-auto-merge-` prefix keeps this distinct from any group the caller may already hold on `<workflow>-<ref>` — without it, the caller and this reusable workflow self-deadlock on the same key and GitHub cancels the job. Repeated invocations on the same PR still replace the previous run.
 - **Major bumps are skipped.** The `if:` condition only matches `version-update:semver-minor` and `version-update:semver-patch`. Other update types fall through without approval or merge.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -33,12 +33,6 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_PAT }}
         run: gh pr review --approve "$PR_URL"
 
-      - name: Wait for Status Checks
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_PAT }}
-        run: gh pr checks -i 20 --watch --required "$PR_URL"
-
       - name: Enable auto-merge for Dependabot PRs
         id: auto-merge
         if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-minor' ||


### PR DESCRIPTION
Remove the shared workflow's dependency on gh pr checks --required, which fails for repos where required checks are enforced through repository rulesets. Callers remain responsible for ordering this reusable workflow behind validation jobs via needs.