### PR TITLE
Skip Spotless only when unavailable

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -27,6 +27,11 @@ on:
         required: false
         description: Path to a markdown-lint rules.json. Empty uses the bundled default from github-actions/config/markdown-lint/rules.json.
         default: ''
+      spotless-gradle-init:
+        type: string
+        required: false
+        description: Path to a Spotless Gradle init script. Empty uses the bundled default from github-actions/config/spotless/spotless.gradle.kts.
+        default: ''
 
 jobs:
   linters:
@@ -77,6 +82,18 @@ jobs:
             echo "path=/tmp/markdown-lint-rules.json" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve Spotless Gradle init script
+        id: spotless-config
+        env:
+          OVERRIDE: ${{ inputs.spotless-gradle-init }}
+        run: |
+          if [[ -n "$OVERRIDE" ]]; then
+            echo "path=$OVERRIDE" >> "$GITHUB_OUTPUT"
+          else
+            curl -fsSL https://raw.githubusercontent.com/yonatankarp/github-actions/v2/config/spotless/spotless.gradle.kts -o /tmp/spotless.gradle.kts
+            echo "path=/tmp/spotless.gradle.kts" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Lint Documents
         if: ${{ inputs.check_docs && steps.changes.outputs.docs == 'true' }}
         uses: avto-dev/markdown-lint@v1
@@ -84,22 +101,6 @@ jobs:
           config: ${{ steps.md-config.outputs.path }}
           args: '**/*.md'
 
-      - name: Check for spotlessCheck task
-        if: ${{ inputs.check_style && steps.changes.outputs.source_code == 'true' }}
-        id: spotless
-        shell: bash
-        run: |
-          if [[ ! -x ./gradlew ]]; then
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          if ./gradlew tasks --all --console=plain | grep -q '^spotlessCheck '; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Check Style
-        if: ${{ inputs.check_style && steps.changes.outputs.source_code == 'true' && steps.spotless.outputs.available == 'true' }}
-        run: ./gradlew spotlessCheck
+        if: ${{ inputs.check_style && steps.changes.outputs.source_code == 'true' }}
+        run: ./gradlew --init-script "${{ steps.spotless-config.outputs.path }}" spotlessCheck

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -83,6 +83,7 @@ jobs:
           fi
 
       - name: Resolve Spotless Gradle init script
+        if: ${{ inputs.check_style && steps.changes.outputs.source_code == 'true' }}
         id: spotless-config
         env:
           OVERRIDE: ${{ inputs.spotless-gradle-init }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -84,6 +84,22 @@ jobs:
           config: ${{ steps.md-config.outputs.path }}
           args: '**/*.md'
 
-      - name: Check Style
+      - name: Check for spotlessCheck task
         if: ${{ inputs.check_style && steps.changes.outputs.source_code == 'true' }}
+        id: spotless
+        shell: bash
+        run: |
+          if [[ ! -x ./gradlew ]]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if ./gradlew tasks --all --console=plain | grep -q '^spotlessCheck '; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check Style
+        if: ${{ inputs.check_style && steps.changes.outputs.source_code == 'true' && steps.spotless.outputs.available == 'true' }}
         run: ./gradlew spotlessCheck

--- a/config/spotless/spotless.gradle.kts
+++ b/config/spotless/spotless.gradle.kts
@@ -1,0 +1,27 @@
+initscript {
+    repositories {
+        gradlePluginPortal()
+    }
+
+    dependencies {
+        classpath("com.diffplug.spotless:spotless-plugin-gradle:8.6.0")
+    }
+}
+
+allprojects {
+    pluginManager.withPlugin("org.jetbrains.kotlin.jvm") {
+        plugins.apply(com.diffplug.gradle.spotless.SpotlessPlugin::class.java)
+
+        extensions.configure<com.diffplug.gradle.spotless.SpotlessExtension>("spotless") {
+            kotlin {
+                target("**/*.kt")
+                ktlint()
+            }
+
+            kotlinGradle {
+                target("**/*.gradle.kts")
+                ktlint()
+            }
+        }
+    }
+}


### PR DESCRIPTION
Keep style linting enabled by default, but avoid failing repositories that do not define a spotlessCheck task. This fixes Dependabot linter failures without disabling the linter job at the caller.