### PR TITLE
Standardize Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/ouroboros.yml
+++ b/.github/workflows/ouroboros.yml
@@ -45,9 +45,12 @@ jobs:
       gradle-module: ${{ matrix.gradle_module }}
 
   dependabot_auto_merge:
-    needs: pipeline
+    needs:
+      - pipeline
+      - linters
+      - actions-linter
     if: ${{ github.actor == 'dependabot[bot]' }}
-    uses: ./.github/workflows/dependabot-auto-merge.yml
+    uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v2
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Purpose
Use the shared Dependabot auto-merge workflow consistently.

## Changes
- Call `yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v2`
- Keep auto-merge gated to Dependabot PRs
- Ensure auto-merge depends on the repo validation job before running

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD workflow reliability by improving job dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yonatankarp/github-actions/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->