### PR TITLE
fix: arm native auto-merge instead of admin-merging Dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.md
+++ b/.github/workflows/dependabot-auto-merge.md
@@ -6,7 +6,7 @@ Behavior:
 
 1. Fetch Dependabot metadata for the PR.
 2. Approve the PR (only for minor/patch updates).
-3. `gh pr merge --admin --rebase`.
+3. `gh pr merge --auto --rebase` — arms GitHub's **native auto-merge**, which merges once branch protection is satisfied (falls back to a direct merge when auto-merge can't be armed, e.g. no required checks).
 
 **Major-version bumps are intentionally _not_ auto-merged** — they need a human eye.
 
@@ -53,6 +53,8 @@ jobs:
 ## Notes
 
 - **PAT, not `GITHUB_TOKEN`.** Dependabot PRs can't be approved by the same user (the bot is the author), and the default `GITHUB_TOKEN` lacks the cross-actor approval permission. A PAT (or fine-grained token with `pull_requests: write` + `contents: write`) is required.
-- **Validation ordering.** The caller must put this workflow behind its validation jobs with `needs:`. The reusable workflow does not call `gh pr checks --required` because rulesets can report required checks differently from classic branch protection.
+- **No `needs:` required.** The merge is gated by GitHub's native auto-merge, which waits on whatever branch protection currently requires (required checks, up-to-date branch, conversation resolution). Adding a new required check in the consumer repo needs no workflow change. This also works identically for classic branch protection and rulesets, and is unaffected by `enforce_admins` — no bypass is attempted.
+- **"Allow auto-merge" must be enabled** in the consumer repo settings (`Settings → General → Allow auto-merge`), otherwise arming fails.
+- **Red checks leave the PR pending, not force-merged.** Unlike the previous `--admin` merge, a failing required check means the PR sits approved with auto-merge armed until checks go green. Failure visibility shifts from "CI job red" to "PR didn't merge".
 - **Concurrency.** The workflow declares `concurrency: group: dependabot-auto-merge-<workflow>-<ref>`. The `dependabot-auto-merge-` prefix keeps this distinct from any group the caller may already hold on `<workflow>-<ref>` — without it, the caller and this reusable workflow self-deadlock on the same key and GitHub cancels the job. Repeated invocations on the same PR still replace the previous run.
 - **Major bumps are skipped.** The `if:` condition only matches `version-update:semver-minor` and `version-update:semver-patch`. Other update types fall through without approval or merge.

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -40,4 +40,7 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_PAT }}
-        run: gh pr merge --admin --rebase "$PR_URL"
+        # --auto arms GitHub's native auto-merge, which merges once branch
+        # protection is satisfied. Fallback to a direct merge for PRs where
+        # auto-merge cannot be armed (no required checks -> already "clean").
+        run: gh pr merge --auto --rebase "$PR_URL" || gh pr merge --rebase "$PR_URL"

--- a/.github/workflows/ouroboros.yml
+++ b/.github/workflows/ouroboros.yml
@@ -45,10 +45,6 @@ jobs:
       gradle-module: ${{ matrix.gradle_module }}
 
   dependabot_auto_merge:
-    needs:
-      - pipeline
-      - linters
-      - actions-linter
     if: ${{ github.actor == 'dependabot[bot]' }}
     uses: yonatankarp/github-actions/.github/workflows/dependabot-auto-merge.yml@v2
     permissions:


### PR DESCRIPTION
## Problem

`dependabot-auto-merge.yml` runs `gh pr merge --admin --rebase` the moment a Dependabot PR opens. In consumer repos this races the required status checks (still in `expected` state), and `--admin` cannot bypass them when the branch protection has **"Do not allow bypassing the above settings"** (`enforce_admins`) enabled. Every minor/patch Dependabot PR then fails with:

```
GraphQL: 4 of 4 required status checks are expected. (mergePullRequest)
```

Observed live on `agent-desk` PRs #93–#97 after the v2 contract change in `2547345` removed the internal `gh pr checks --watch --required` wait (callers were expected to add `needs:`, but that has to be kept in sync with every new validation job — easy to miss, silently).

## Fix

Use `gh pr merge --auto --rebase`: arms GitHub's **native auto-merge**, so GitHub itself gates the merge on whatever branch protection currently requires (required checks, up-to-date branch, conversation resolution).

- **No `needs:` maintenance** — adding a new required check in a consumer repo needs no workflow change.
- **No race** — arming while checks are pending is the intended use.
- **Ruleset & classic protection friendly** — GitHub evaluates the requirements natively; `gh` never enumerates them. `enforce_admins` is irrelevant since no bypass is attempted.
- **Fallback**: `|| gh pr merge --rebase` covers PRs where auto-merge can't be armed (repo with no required checks → PR already "clean"). A plain non-admin merge is still fully gated by protection wherever it exists.

Also drops the now-unneeded `needs:` from `ouroboros.yml` and updates the docs (including the new requirement that consumer repos enable **Allow auto-merge** — verified all 14 current consumer repos already have it on).

## Behavior change

Red required checks now leave the PR approved + armed but **unmerged** (previously `--admin` would have force-merged where it could). For dependency bumps that's the safer default, but failure visibility shifts from "CI job red" to "PR didn't merge".

⚠️ Note: `move-major-tag.yml` advances `v2` on every push to `main`, so this ships to all consumers immediately on merge. Verification plan: re-run a failed `dependabot` job on `agent-desk` #93–#97 and confirm auto-merge arms and merges after checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)